### PR TITLE
Missing hidden tax

### DIFF
--- a/app/code/core/Mage/Paypal/Model/Hostedpro/Request.php
+++ b/app/code/core/Mage/Paypal/Model/Hostedpro/Request.php
@@ -157,7 +157,7 @@ class Mage_Paypal_Model_Hostedpro_Request extends Varien_Object
     {
         $request = array(
             'subtotal'      => $this->_formatPrice($order->getBaseSubtotal()),
-            'tax'           => $this->_formatPrice($order->getBaseTaxAmount()),
+            'tax'           => $this->_formatPrice($order->getBaseTaxAmount() + $order->getHiddenTaxAmount() ),
             'shipping'      => $this->_formatPrice($order->getBaseShippingAmount()),
             'invoice'       => $order->getIncrementId(),
             'address_override' => 'true',


### PR DESCRIPTION
will cause paypal to generate fraud error